### PR TITLE
Attach headers to the resp's meta + handle headers for PUT/PATCH

### DIFF
--- a/curling/test.py
+++ b/curling/test.py
@@ -167,3 +167,11 @@ class TestStatsd(unittest.TestCase):
     def test_post(self):
         self.api.services.settings.post(data={})
         eq_(lib.statsd.cache, {'services.settings.POST.200|count': [[1, 1]]})
+
+    def test_put(self):
+        self.api.services.settings.put(data={})
+        eq_(lib.statsd.cache, {'services.settings.PUT.200|count': [[1, 1]]})
+
+    def test_patch(self):
+        self.api.services.settings.patch(data={})
+        eq_(lib.statsd.cache, {'services.settings.PATCH.200|count': [[1, 1]]})

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='curling',
-    version='0.2.8',
+    version='0.2.9',
     description='Slumber wrapper for Django that works well with Tastypie',
     long_description=open('README.rst').read(),
     author='Andy McKay',


### PR DESCRIPTION
Both are necessary to handle etags in webpay (bug 845967)
