### PR TITLE
Prevent attribute error on first use of curling

### DIFF
--- a/curling/command.py
+++ b/curling/command.py
@@ -22,10 +22,12 @@ import lib
 
 
 def get_config():
+    conf = {}
     for filename in ['.curling', '~/.curling']:
         full = os.path.expanduser(filename)
         if os.path.exists(full):
-            return json.load(open(full, 'r'))
+            conf = json.load(open(full, 'r'))
+    return conf
 
 
 def get_domain(domain):


### PR DESCRIPTION
Since the conf doesn't exist you see None has not attibute 'get'
