### PR TITLE
Fix error when statsd is absent or not configured

### DIFF
--- a/curling/lib.py
+++ b/curling/lib.py
@@ -12,7 +12,8 @@ import oauth2 as oauth
 try:
     from django_statsd.clients import statsd
 except (ImportError, ImproperlyConfigured):
-    statsd = mock.MagicMock()
+    from mock import MagicMock
+    statsd = MagicMock()
 
 from requests.exceptions import ConnectionError
 


### PR DESCRIPTION
Tried to add a test, but it's pretty difficult to do so I gave up.