### PR TITLE
Switch to oauthlib, add support for query string through command line API

### DIFF
--- a/curling/command.py
+++ b/curling/command.py
@@ -6,8 +6,8 @@ import os
 import sys
 import tempfile
 import urlparse
-import sys
 import webbrowser
+from collections import OrderedDict
 
 from pygments import highlight
 try:
@@ -80,9 +80,10 @@ def new(config, lib_api=None):
         return
 
     method = getattr(api, config.request.lower())
+    query_dict = OrderedDict(urlparse.parse_qsl(str(url.query)))
 
     try:
-        res = method(data=config.data)
+        res = method(config.data, headers=None, **query_dict)
         if 'meta' in res:
             res['meta']['headers'] = dict(res['meta']['headers'])
     except HttpClientError, err:
@@ -139,5 +140,5 @@ def main():
         new(config)
 
 
-if __name__=='__main__':
+if __name__ == '__main__':
     main()

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@ django-statsd-mozilla==0.3.8.6
 httplib2
 mock
 pygments
-oauth2==1.5.211
+oauthlib==0.7.2
 requests>=2.0.0
-slumber==0.5.3
+slumber==0.6.2
 statsd==1.0.0


### PR DESCRIPTION
This is to make the following work:

`% curling -i 'https://marketplace.allizom.org/api/v2/langpacks/?active=false'`

With the current code, curling actually ignores the query string and does a request to https://marketplace.allizom.org/api/v2/langpacks/, which is not what I need, so here is my attempt to fix it.

I also switched to oauthlib to get rid of the oauth2 dependency, which is insecure and unmaintained  : https://github.com/simplegeo/python-oauth2/issues/129 ; this could be done in a separate pull request if needed.

I know very little about curling, slumber, oauthlib vs oauth2, and although my patch seems to work for me, but it might have broken subtle things I don't understand/use yet, so take your time ;) 