### PR TITLE
Make --data-binary work in curling command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+docs/build/

--- a/curling/lib.py
+++ b/curling/lib.py
@@ -169,8 +169,12 @@ class TastypieResource(TastypieAttributesMixin, Resource):
         """
         Allow a body in GET, because that's just fine.
         """
-        s = self._store['serializer']
-        resp = self._request('GET', data=s.dumps(data) if data else None,
+        if data:
+            s = self._store['serializer']
+            data = data if kwargs.get('binary_data') else s.dumps(data)
+        else:
+            data = None
+        resp = self._request('GET', data=data,
                              headers=headers, params=kwargs)
         if 200 <= resp.status_code <= 299:
             return self._try_to_serialize_response(resp)
@@ -181,8 +185,9 @@ class TastypieResource(TastypieAttributesMixin, Resource):
 
     def post(self, data, headers=None, **kwargs):
         s = self._store['serializer']
+        data = data if kwargs.get('binary_data') else s.dumps(data)
 
-        resp = self._request('POST', data=s.dumps(data),
+        resp = self._request('POST', data=data,
                              headers=headers, params=kwargs)
         if 200 <= resp.status_code <= 299:
             return self._try_to_serialize_response(resp)
@@ -192,8 +197,9 @@ class TastypieResource(TastypieAttributesMixin, Resource):
 
     def patch(self, data, headers=None, **kwargs):
         s = self._store['serializer']
+        data = data if kwargs.get('binary_data') else s.dumps(data)
 
-        resp = self._request('PATCH', data=s.dumps(data),
+        resp = self._request('PATCH', data=data,
                              headers=headers, params=kwargs)
         if 200 <= resp.status_code <= 299:
             return self._try_to_serialize_response(resp)
@@ -203,8 +209,9 @@ class TastypieResource(TastypieAttributesMixin, Resource):
 
     def put(self, data, headers=None, **kwargs):
         s = self._store['serializer']
+        data = data if kwargs.get('binary_data') else s.dumps(data)
 
-        resp = self._request('PUT', data=s.dumps(data),
+        resp = self._request('PUT', data=data,
                              headers=headers, params=kwargs)
         if 200 <= resp.status_code <= 299:
             return self._try_to_serialize_response(resp)

--- a/docs/source/topics/command.rst
+++ b/docs/source/topics/command.rst
@@ -23,10 +23,16 @@ options:
 
 * -h or --help: show help
 * -d or --data: data to be sent, must be valid JSON
+* --data-binary: binary data to be sent, cannot be used with --data.
+  When this option is used, Content-Disposition and Content-Type headers are
+  automatically set.
 * -X or --request: the verb to be sent, e.g.: curling -X POST to send a POST
 * -i or --include: include the HTTP response headers in the output (legacy
   only)
 * -l or --legacy: use the old style command (see below)
+
+The --data and --data-binary options can be the special value '@-', in which
+case the data is read from stdin.
 
 Legacy
 ======


### PR DESCRIPTION
I'm working on an API that accepts a file directly, I'm sick of having to encode my data in base64. `curl` accepts a --data-binary argument, so this is an attempt to emulate that. The idea is to make the following work:

```
cat /tmp/extension.zip | python curling/command.py -X POST --data-binary @- http://localhost:8000/api/v2/extensions/validation/
```
